### PR TITLE
Ranks GUI

### DIFF
--- a/src/main/java/de/lxca/slimeRanks/Main.java
+++ b/src/main/java/de/lxca/slimeRanks/Main.java
@@ -2,6 +2,7 @@ package de.lxca.slimeRanks;
 
 import de.lxca.slimeRanks.commands.SlimeranksCommand;
 import de.lxca.slimeRanks.listeners.*;
+import de.lxca.slimeRanks.objects.Message;
 import de.lxca.slimeRanks.objects.Metrics;
 import de.lxca.slimeRanks.objects.RankManager;
 import de.lxca.slimeRanks.objects.TeamManager;
@@ -84,5 +85,12 @@ public final class Main extends JavaPlugin {
 
     public static RanksYml getRanksYml() {
         return ranksYml;
+    }
+
+    public static void reload() {
+        Message.resetPrefix();
+        Main.initializeVariables();
+        RankManager.getInstance().reloadRanks();
+        RankManager.getInstance().reloadDisplays();
     }
 }

--- a/src/main/java/de/lxca/slimeRanks/Main.java
+++ b/src/main/java/de/lxca/slimeRanks/Main.java
@@ -31,6 +31,7 @@ public final class Main extends JavaPlugin {
 
         PluginManager pluginManager = Bukkit.getPluginManager();
         pluginManager.registerEvents(new AsyncChatListener(), this);
+        pluginManager.registerEvents(new InventoryClickListener(), this);
         pluginManager.registerEvents(new PlayerChangedWorldListener(), this);
         pluginManager.registerEvents(new PlayerDeathListener(), this);
         pluginManager.registerEvents(new PlayerGameModeChangeListener(), this);

--- a/src/main/java/de/lxca/slimeRanks/Main.java
+++ b/src/main/java/de/lxca/slimeRanks/Main.java
@@ -46,7 +46,7 @@ public final class Main extends JavaPlugin {
         }
 
         if (!Bukkit.getOnlinePlayers().isEmpty()) {
-            RankManager.getInstance().reload();
+            RankManager.getInstance().reloadDisplays();
         }
 
         initializeMetrics();

--- a/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
+++ b/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
@@ -33,9 +33,7 @@ public class SlimeranksCommand extends Command {
                 new Message(commandSender, false, "Chat.Command.Help");
                 return true;
             } else if (strings[0].equalsIgnoreCase("reload")) {
-                Message.resetPrefix();
-                Main.initializeVariables();
-                RankManager.getInstance().reload();
+                Main.reload();
                 new Message(commandSender, true, "Chat.Command.Reload");
                 return true;
             } else {

--- a/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
+++ b/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
@@ -2,7 +2,6 @@ package de.lxca.slimeRanks.commands;
 
 import de.lxca.slimeRanks.Main;
 import de.lxca.slimeRanks.objects.Message;
-import de.lxca.slimeRanks.objects.RankManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
+++ b/src/main/java/de/lxca/slimeRanks/commands/SlimeranksCommand.java
@@ -1,9 +1,11 @@
 package de.lxca.slimeRanks.commands;
 
 import de.lxca.slimeRanks.Main;
+import de.lxca.slimeRanks.guis.RankOverviewGui;
 import de.lxca.slimeRanks.objects.Message;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -29,6 +31,14 @@ public class SlimeranksCommand extends Command {
             if (strings[0].equalsIgnoreCase("about")) {
                 sendAboutMessage(commandSender);
                 return true;
+            } else if (strings[0].equalsIgnoreCase("gui")) {
+                if (commandSender instanceof Player player) {
+                    player.openInventory(new RankOverviewGui().getInventory());
+                    return true;
+                } else {
+                    new Message(commandSender, true, "Chat.Command.OnlyPlayers");
+                    return false;
+                }
             } else if (strings[0].equalsIgnoreCase("help")) {
                 new Message(commandSender, false, "Chat.Command.Help");
                 return true;
@@ -67,6 +77,7 @@ public class SlimeranksCommand extends Command {
         ArrayList<String> completerList = new ArrayList<>();
         if (args.length == 1 && sender.hasPermission("slimeranks.admin")) {
             completerList.add("about");
+            completerList.add("gui");
             completerList.add("help");
             completerList.add("reload");
         }

--- a/src/main/java/de/lxca/slimeRanks/enums/ChatInputType.java
+++ b/src/main/java/de/lxca/slimeRanks/enums/ChatInputType.java
@@ -1,0 +1,10 @@
+package de.lxca.slimeRanks.enums;
+
+public enum ChatInputType {
+    RANK_IDENTIFIER,
+    RANK_TAB_FORMAT,
+    RANK_CHAT_FORMAT,
+    RANK_NAME_TAG_FORMAT,
+    RANK_TAB_PRIORITY,
+    RANK_PERMISSION,
+}

--- a/src/main/java/de/lxca/slimeRanks/guis/RankEditGui.java
+++ b/src/main/java/de/lxca/slimeRanks/guis/RankEditGui.java
@@ -1,0 +1,132 @@
+package de.lxca.slimeRanks.guis;
+
+import de.lxca.slimeRanks.Main;
+import de.lxca.slimeRanks.enums.ChatInputType;
+import de.lxca.slimeRanks.items.GlobalItems;
+import de.lxca.slimeRanks.items.EditItems;
+import de.lxca.slimeRanks.objects.ChatInput;
+import de.lxca.slimeRanks.objects.Message;
+import de.lxca.slimeRanks.objects.Rank;
+import de.lxca.slimeRanks.objects.RankManager;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+
+public class RankEditGui implements InventoryHolder {
+
+    private static final int guiSize = 4 * 9;
+
+    private final Inventory inventory;
+    private final Rank rank;
+
+    public RankEditGui(Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("identifier", rank.getIdentifier());
+
+        this.inventory = Main.getInstance().getServer().createInventory(
+                this,
+                guiSize,
+                new Message("Gui.Edit.Title", replacements).getMessage()
+        );
+        this.rank = rank;
+
+        setItems();
+    }
+
+    private void setItems() {
+        for (int i = 0; i < guiSize; i++) {
+            inventory.setItem(i, GlobalItems.getBackgroundItem());
+        }
+
+        inventory.setItem(4, GlobalItems.getRankItem(rank));
+        inventory.setItem(10, EditItems.getTablistItem(rank));
+        inventory.setItem(11, EditItems.getChatItem(rank));
+        inventory.setItem(12, EditItems.getNameTagItem(rank));
+        inventory.setItem(14, EditItems.getTabPriorityItem(rank));
+        inventory.setItem(15, EditItems.getPermissionItem(rank));
+        inventory.setItem(16, EditItems.getHideOnSneakItem(rank));
+        inventory.setItem(19, EditItems.getStatusItem(rank.tabIsActive()));
+        inventory.setItem(20, EditItems.getStatusItem(rank.chatIsActive()));
+        inventory.setItem(21, EditItems.getStatusItem(rank.nameTagIsActive()));
+        inventory.setItem(23, EditItems.getPriorityStatusItem(rank.getPriority()));
+        inventory.setItem(24, EditItems.getPermissionStatusItem(rank.getPermission()));
+        inventory.setItem(25, EditItems.getStatusItem(rank.hideNameTagOnSneak()));
+        inventory.setItem(27, GlobalItems.getBackItem());
+        inventory.setItem(35, EditItems.getDeleteItem());
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        return inventory;
+    }
+
+    public void clickHandler(@NotNull InventoryClickEvent event) {
+        event.setCancelled(true);
+
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+
+        if (slot == 10) {
+            Component additionalInfoMessage = new Message("Chat.Input.TabFormat", true).getMessage();
+            new ChatInput(player, ChatInputType.RANK_TAB_FORMAT, 120, rank, additionalInfoMessage);
+            player.closeInventory();
+        } else if (slot == 11) {
+            Component additionalInfoMessage = new Message("Chat.Input.ChatFormat", true).getMessage();
+            new ChatInput(player, ChatInputType.RANK_CHAT_FORMAT, 120, rank, additionalInfoMessage);
+            player.closeInventory();
+        } else if (slot == 12) {
+            Component additionalInfoMessage = new Message("Chat.Input.NameTagFormat", true).getMessage();
+            new ChatInput(player, ChatInputType.RANK_NAME_TAG_FORMAT, 120, rank, additionalInfoMessage);
+            player.closeInventory();
+        } else if (slot == 19) {
+            rank.setTabActive(!rank.tabIsActive());
+            inventory.setItem(slot, EditItems.getStatusItem(rank.tabIsActive()));
+            RankManager.getInstance().reloadDisplays();
+            player.playSound(player, Sound.BLOCK_LEVER_CLICK, 1.0F, 1.0F);
+        } else if (slot == 20) {
+            rank.setChatActive(!rank.chatIsActive());
+            inventory.setItem(slot, EditItems.getStatusItem(rank.chatIsActive()));
+            RankManager.getInstance().reloadDisplays();
+            player.playSound(player, Sound.BLOCK_LEVER_CLICK, 1.0F, 1.0F);
+        } else if (slot == 21) {
+            rank.setNameTagActive(!rank.nameTagIsActive());
+            inventory.setItem(slot, EditItems.getStatusItem(rank.nameTagIsActive()));
+            RankManager.getInstance().reloadDisplays();
+            player.playSound(player, Sound.BLOCK_LEVER_CLICK, 1.0F, 1.0F);
+        } else if (slot == 23) {
+            Component additionalInfoMessage = new Message("Chat.Input.TabPriority", true).getMessage();
+            new ChatInput(player, ChatInputType.RANK_TAB_PRIORITY, 30, rank, additionalInfoMessage);
+            player.closeInventory();
+        } else if (slot == 24) {
+            if (event.getClick() == ClickType.DOUBLE_CLICK) {
+                rank.setPermission(null);
+                inventory.setItem(slot, EditItems.getPermissionStatusItem(rank.getPermission()));
+                RankManager.getInstance().reloadDisplays();
+                player.playSound(player, Sound.BLOCK_LAVA_POP, 1.0F, 1.0F);
+            } else {
+                Component additionalInfoMessage = new Message("Chat.Input.Permission", true).getMessage();
+                new ChatInput(player, ChatInputType.RANK_PERMISSION, 30, rank, additionalInfoMessage);
+                player.closeInventory();
+            }
+        } else if (slot == 25) {
+            rank.setHideNameTagOnSneak(!rank.hideNameTagOnSneak());
+            inventory.setItem(slot, EditItems.getStatusItem(rank.hideNameTagOnSneak()));
+            RankManager.getInstance().reloadDisplays();
+            player.playSound(player, Sound.BLOCK_LEVER_CLICK, 1.0F, 1.0F);
+        } else if (slot == 27) {
+            player.openInventory(new RankOverviewGui().getInventory());
+            player.playSound(player, Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
+        } else if (slot == 35 && event.getClick() == ClickType.DOUBLE_CLICK) {
+            rank.delete();
+            player.openInventory(new RankOverviewGui().getInventory());
+            player.playSound(player, Sound.ENTITY_GENERIC_EXPLODE, 1.0F, 1.0F);
+        }
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/guis/RankOverviewGui.java
+++ b/src/main/java/de/lxca/slimeRanks/guis/RankOverviewGui.java
@@ -1,0 +1,110 @@
+package de.lxca.slimeRanks.guis;
+
+import de.lxca.slimeRanks.Main;
+import de.lxca.slimeRanks.enums.ChatInputType;
+import de.lxca.slimeRanks.items.GlobalItems;
+import de.lxca.slimeRanks.items.OverviewItems;
+import de.lxca.slimeRanks.objects.ChatInput;
+import de.lxca.slimeRanks.objects.Message;
+import de.lxca.slimeRanks.objects.Rank;
+import de.lxca.slimeRanks.objects.RankManager;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankOverviewGui implements InventoryHolder {
+
+    private static final int guiSize = 4 * 9;
+    private static final List<Integer> rankSlots = List.of(10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25);
+
+    private final Inventory inventory;
+    private ArrayList<Rank> ranks;
+    private int page;
+
+    public RankOverviewGui() {
+        this.inventory = Main.getInstance().getServer().createInventory(
+                this,
+                guiSize,
+                new Message("Gui.Overview.Title").getMessage()
+        );
+        setRanks();
+        this.page = 1;
+
+        setItems();
+    }
+
+    private void setRanks() {
+        this.ranks = RankManager.getInstance().getRanks();
+    }
+
+    private void setItems() {
+        for (int i = 0; i < guiSize; i++) {
+           inventory.setItem(i, GlobalItems.getBackgroundItem());
+        }
+
+        inventory.setItem(4, OverviewItems.getTitleItem());
+        for (Integer rankSlot : rankSlots) {
+            if (ranks.size() > ((page - 1) * rankSlots.size()) + rankSlots.indexOf(rankSlot)) {
+                Rank rank = ranks.get(((page - 1) * rankSlots.size()) + rankSlots.indexOf(rankSlot));
+                inventory.setItem(rankSlot, GlobalItems.getRankItem(rank));
+            } else {
+                inventory.clear(rankSlot);
+            }
+        }
+        inventory.setItem(27, GlobalItems.getCloseItem());
+        inventory.setItem(30, GlobalItems.getPreviousPageItem(page > 1));
+        inventory.setItem(32, GlobalItems.getNextPageItem(ranks.size() > (page * rankSlots.size())));
+        inventory.setItem(34, OverviewItems.getReloadItem());
+        inventory.setItem(35, OverviewItems.getCreateRankItem());
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        return inventory;
+    }
+
+    public void clickHandler(@NotNull InventoryClickEvent event) {
+        event.setCancelled(true);
+
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+
+        if (rankSlots.contains(slot)) {
+            if (ranks.size() > ((page - 1) * rankSlots.size()) + rankSlots.indexOf(slot)) {
+                Rank rank = ranks.get(((page - 1) * rankSlots.size()) + rankSlots.indexOf(slot));
+                player.openInventory(new RankEditGui(rank).getInventory());
+                player.playSound(player, Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
+            }
+        } else if (slot == 27) {
+            player.closeInventory();
+        } else if (slot == 30) {
+            if (page > 1) {
+                page--;
+                setItems();
+                player.playSound(player, Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
+            }
+        } else if (slot == 32) {
+            if (ranks.size() > page * rankSlots.size()) {
+                page++;
+                setItems();
+                player.playSound(player, Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 1.0F);
+            }
+        } else if (slot == 34) {
+            Main.reload();
+            setRanks();
+            setItems();
+            player.playSound(player, Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 2.0F);
+        } else if (slot == 35) {
+            Component additionalInfoMessage = new Message("Chat.Input.CreateRank", true).getMessage();
+            new ChatInput(player, ChatInputType.RANK_IDENTIFIER, 30, additionalInfoMessage);
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/items/EditItems.java
+++ b/src/main/java/de/lxca/slimeRanks/items/EditItems.java
@@ -1,0 +1,134 @@
+package de.lxca.slimeRanks.items;
+
+import de.lxca.slimeRanks.objects.ItemBuilder;
+import de.lxca.slimeRanks.objects.Rank;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+
+public class EditItems {
+
+    public static ItemStack getTablistItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("format", rank.getRawTabFormat());
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.JUNGLE_SIGN);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.Tablist");
+        itemBuilder.setLore("Gui.Edit.ItemLore.Tablist", replacements);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getChatItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("format", rank.getRawChatFormat());
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.WRITABLE_BOOK);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.Chat");
+        itemBuilder.setLore("Gui.Edit.ItemLore.Chat", replacements);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getNameTagItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("format", rank.getRawNameTagFormat());
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.NAME_TAG);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.NameTag");
+        itemBuilder.setLore("Gui.Edit.ItemLore.NameTag", replacements);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getTabPriorityItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("priority", String.valueOf(rank.getPriority()));
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.NETHERITE_UPGRADE_SMITHING_TEMPLATE);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.TabPriority");
+        itemBuilder.setLore("Gui.Edit.ItemLore.TabPriority", replacements);
+
+        itemBuilder.addItemFlag(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+        itemBuilder.addItemFlag(ItemFlag.HIDE_ATTRIBUTES);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getPermissionItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("permission", rank.getPermission() == null ? "%Placeholder.None" : rank.getPermission());
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.FLOWER_BANNER_PATTERN);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.Permission");
+        itemBuilder.setLore("Gui.Edit.ItemLore.Permission", replacements);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getHideOnSneakItem(@NotNull Rank rank) {
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("status", rank.hideNameTagOnSneak() ? "%Placeholder.Yes" : "%Placeholder.No");
+
+        ItemBuilder itemBuilder = new ItemBuilder(Material.ENDER_EYE);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.HideOnSneak");
+        itemBuilder.setLore("Gui.Edit.ItemLore.HideOnSneak", replacements);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getStatusItem(boolean active) {
+        ItemBuilder itemBuilder = new ItemBuilder(active ? Material.LIME_DYE : Material.GRAY_DYE);
+
+        if (active) {
+            itemBuilder.setItemName("Gui.Edit.ItemName.Status.Activated");
+            itemBuilder.setLore("Gui.Edit.ItemLore.Status.Activated");
+        } else {
+            itemBuilder.setItemName("Gui.Edit.ItemName.Status.Deactivated");
+            itemBuilder.setLore("Gui.Edit.ItemLore.Status.Deactivated");
+        }
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getPriorityStatusItem(int priority) {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.IRON_NUGGET, priority <= 0 ? 1 : Math.min(priority, 64));
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("priority", String.valueOf(priority));
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.PriorityStatus", replacements);
+        itemBuilder.setLore("Gui.Edit.ItemLore.PriorityStatus");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getPermissionStatusItem(@Nullable String permission) {
+        ItemBuilder itemBuilder = new ItemBuilder(permission == null ? Material.STRUCTURE_VOID : Material.PAPER);
+        HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("permission", permission == null ? "%Placeholder.None" : permission);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.PermissionStatus", replacements);
+        itemBuilder.setLore("Gui.Edit.ItemLore.PermissionStatus");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getDeleteItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.LAVA_BUCKET);
+
+        itemBuilder.setItemName("Gui.Edit.ItemName.Delete");
+        itemBuilder.setLore("Gui.Edit.ItemLore.Delete");
+
+        return itemBuilder.getItemStack();
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/items/GlobalItems.java
+++ b/src/main/java/de/lxca/slimeRanks/items/GlobalItems.java
@@ -1,0 +1,76 @@
+package de.lxca.slimeRanks.items;
+
+import de.lxca.slimeRanks.objects.ItemBuilder;
+import de.lxca.slimeRanks.objects.Rank;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+
+public class GlobalItems {
+
+    public static ItemStack getBackgroundItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE);
+
+        itemBuilder.setHideTooltip(true);
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getCloseItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.BARRIER);
+
+        itemBuilder.setItemName("Gui.Global.ItemName.Close");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getBackItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.ARROW);
+
+        itemBuilder.setItemName("Gui.Global.ItemName.Back");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getPreviousPageItem(boolean pageAvailable) {
+        ItemBuilder itemBuilder = new ItemBuilder(pageAvailable ? Material.LIME_DYE : Material.GRAY_DYE);
+
+        itemBuilder.setItemName("Gui.Global.ItemName.PreviousPage");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getNextPageItem(boolean pageAvailable) {
+        ItemBuilder itemBuilder = new ItemBuilder(pageAvailable ? Material.LIME_DYE : Material.GRAY_DYE);
+
+        itemBuilder.setItemName("Gui.Global.ItemName.NextPage");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getRankItem(@NotNull Rank rank) {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.FILLED_MAP);
+        HashMap<String, String> nameReplacements = new HashMap<>();
+        HashMap<String, String> loreReplacements = new HashMap<>();
+
+        nameReplacements.put("identifier", rank.getIdentifier());
+        loreReplacements.put("identifier", rank.getIdentifier());
+        loreReplacements.put("tablist_format", rank.getRawTabFormat());
+        loreReplacements.put("chat_format", rank.getRawChatFormat());
+        loreReplacements.put("name_tag_format", rank.getRawNameTagFormat());
+        loreReplacements.put("tab_priority", String.valueOf(rank.getPriority()));
+        loreReplacements.put("permission", rank.getPermission() == null ? "%Placeholder.None" : rank.getPermission());
+        loreReplacements.put("hide_name_tag_on_sneak", rank.hideNameTagOnSneak() ? "%Placeholder.Yes" : "%Placeholder.No");
+
+        itemBuilder.setItemName("Gui.Global.ItemName.Rank", nameReplacements);
+        itemBuilder.setLore("Gui.Global.ItemLore.Rank", loreReplacements);
+
+        itemBuilder.addItemFlag(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+        itemBuilder.addItemFlag(ItemFlag.HIDE_ATTRIBUTES);
+
+        return itemBuilder.getItemStack();
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/items/OverviewItems.java
+++ b/src/main/java/de/lxca/slimeRanks/items/OverviewItems.java
@@ -1,0 +1,35 @@
+package de.lxca.slimeRanks.items;
+
+import de.lxca.slimeRanks.objects.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class OverviewItems {
+
+    public static ItemStack getTitleItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.SLIME_BLOCK);
+
+        itemBuilder.setItemName("Gui.Overview.ItemName.Title");
+        itemBuilder.setLore("Gui.Overview.ItemLore.Title");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getReloadItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.HONEYCOMB);
+
+        itemBuilder.setItemName("Gui.Overview.ItemName.Reload");
+        itemBuilder.setLore("Gui.Overview.ItemLore.Reload");
+
+        return itemBuilder.getItemStack();
+    }
+
+    public static ItemStack getCreateRankItem() {
+        ItemBuilder itemBuilder = new ItemBuilder(Material.CRAFTING_TABLE);
+
+        itemBuilder.setItemName("Gui.Overview.ItemName.CreateRank");
+        itemBuilder.setLore("Gui.Overview.ItemLore.CreateRank");
+
+        return itemBuilder.getItemStack();
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/listeners/AsyncChatListener.java
+++ b/src/main/java/de/lxca/slimeRanks/listeners/AsyncChatListener.java
@@ -1,5 +1,7 @@
 package de.lxca.slimeRanks.listeners;
 
+import de.lxca.slimeRanks.Main;
+import de.lxca.slimeRanks.objects.ChatInput;
 import de.lxca.slimeRanks.objects.Rank;
 import de.lxca.slimeRanks.objects.RankManager;
 import io.papermc.paper.event.player.AsyncChatEvent;
@@ -15,6 +17,14 @@ public class AsyncChatListener implements Listener {
     @EventHandler
     public void onAsyncChat(AsyncChatEvent event) {
         Player player = event.getPlayer();
+
+        if (ChatInput.playerHasActivateChatInputSession(player)) {
+            event.setCancelled(true);
+            Main.getInstance().getServer().getScheduler().runTask(
+                    Main.getInstance(), () -> ChatInput.getChatInputSession(player).executeLogic(event));
+            return;
+        }
+
         Rank rank = RankManager.getInstance().getPlayerRank(player);
 
         if (rank == null || !rank.chatIsActive()) {

--- a/src/main/java/de/lxca/slimeRanks/listeners/InventoryClickListener.java
+++ b/src/main/java/de/lxca/slimeRanks/listeners/InventoryClickListener.java
@@ -1,0 +1,22 @@
+package de.lxca.slimeRanks.listeners;
+
+import de.lxca.slimeRanks.guis.RankEditGui;
+import de.lxca.slimeRanks.guis.RankOverviewGui;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.InventoryHolder;
+
+public class InventoryClickListener implements Listener {
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        InventoryHolder inventoryHolder = event.getInventory().getHolder();
+
+        if (inventoryHolder instanceof RankEditGui gui) {
+            gui.clickHandler(event);
+        } if (inventoryHolder instanceof RankOverviewGui gui) {
+            gui.clickHandler(event);
+        }
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/objects/ChatInput.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/ChatInput.java
@@ -1,0 +1,194 @@
+package de.lxca.slimeRanks.objects;
+
+import de.lxca.slimeRanks.Main;
+import de.lxca.slimeRanks.enums.ChatInputType;
+import de.lxca.slimeRanks.guis.RankEditGui;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.util.HashMap;
+
+public class ChatInput {
+
+    private static final HashMap<Player, ChatInput> chatInputSessions = new HashMap<>();
+
+    private final Player player;
+    private final ChatInputType chatInputType;
+    private final int timerSeconds;
+    private final Object linkedObject;
+    private BukkitTask titleTask;
+
+    public ChatInput(Player player, ChatInputType chatInputType, int timerSeconds, Component infoMessage) {
+        this.player = player;
+        this.chatInputType = chatInputType;
+        this.timerSeconds = timerSeconds;
+        this.linkedObject = null;
+
+        startTimer(infoMessage);
+
+        chatInputSessions.put(player, this);
+    }
+
+    public ChatInput(Player player, ChatInputType chatInputType, int timerSeconds, Object linkedObject, Component infoMessage) {
+        this.player = player;
+        this.chatInputType = chatInputType;
+        this.timerSeconds = timerSeconds;
+        this.linkedObject = linkedObject;
+
+        startTimer(infoMessage);
+
+        chatInputSessions.put(player, this);
+    }
+
+    private void startTimer(Component infoMessage) {
+        new Message(player, true, "Chat.Input.Started");
+        if (infoMessage != null) {
+            player.sendMessage(infoMessage);
+        }
+        player.playSound(player, Sound.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, 1.0F, 1.0F);
+
+        final int[] seconds = {timerSeconds};
+        Runnable titleTaskRunnable = () -> {
+            if (!playerHasActivateChatInputSession(player)) {
+                return;
+            }
+            if (player.isOnline() && seconds[0] > 0) {
+                HashMap<String, String> replacements = new HashMap<>();
+                replacements.put("seconds", String.valueOf(seconds[0]));
+
+                Title.Times times = Title.Times.times(Duration.ZERO, Duration.ofSeconds(1), Duration.ofSeconds(1));
+                Title title = Title.title(
+                        new Message("Title.ChatInput.Main").getMessage(),
+                        new Message("Title.ChatInput.Sub", replacements).getMessage(),
+                        times
+                );
+                player.showTitle(title);
+                seconds[0]--;
+                return;
+            }
+
+            endSession(true, null, false);
+        };
+        titleTask = Bukkit.getScheduler().runTaskTimer(Main.getInstance(), titleTaskRunnable, 0, 20);
+    }
+
+    public void endSession(boolean notifyPlayer, Component additionalInfoMessage, boolean actionSuccessful) {
+        chatInputSessions.remove(player);
+        player.clearTitle();
+        titleTask.cancel();
+        if (notifyPlayer) {
+            if (actionSuccessful) {
+                player.playSound(player, Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 2.0F);
+            } else {
+                player.playSound(player, Sound.ENTITY_WARDEN_SONIC_BOOM, 1.0F, 1.0F);
+            }
+            new Message(player, true, "Chat.Input.Ended");
+            if (additionalInfoMessage != null) {
+                player.sendMessage(additionalInfoMessage);
+            }
+        }
+    }
+
+    public void executeLogic(@NotNull AsyncChatEvent event) {
+        String messageString = PlainTextComponentSerializer.plainText().serialize(event.message());
+
+        if (messageString.equalsIgnoreCase("cancel")) {
+            endSession(true, null, false);
+            return;
+        }
+
+        if (chatInputType == ChatInputType.RANK_IDENTIFIER) {
+            if (!messageString.chars().allMatch(Character::isAlphabetic)) {
+                Component errorMessage = new Message("Chat.Input.RankIdentifier.OnlyLetters", true).getMessage();
+                endSession(true, errorMessage, false);
+                return;
+            }
+            YamlConfiguration ranksYml = Main.getRanksYml().getYmlConfig();
+            ConfigurationSection ranksSection = ranksYml.getConfigurationSection("Ranks");
+
+            if (ranksSection != null && ranksSection.getKeys(false).contains(messageString)) {
+                Component errorMessage = new Message("Chat.Input.RankIdentifier.AlreadyUsed", true).getMessage();
+                endSession(true, errorMessage, false);
+                return;
+            }
+
+            ranksYml.set("Ranks." + messageString + ".Tab.Active", true);
+            ranksYml.set("Ranks." + messageString + ".Tab.Format", "<gray>" + messageString + "</gray> <dark_gray>-</dark_gray> <gray>{player}</gray>");
+            ranksYml.set("Ranks." + messageString + ".Tab.Priority", 0);
+            ranksYml.set("Ranks." + messageString + ".Chat.Active", true);
+            ranksYml.set("Ranks." + messageString + ".Chat.Format", "<gray>" + messageString + "</gray> <dark_gray>-</dark_gray> <gray>{player}</gray><dark_gray>:</dark_gray> <white>{message}</white>");
+            ranksYml.set("Ranks." + messageString + ".NameTag.Active", true);
+            ranksYml.set("Ranks." + messageString + ".NameTag.Format", "<gray>" + messageString + "</gray> <dark_gray>-</dark_gray> <gray>{player}</gray>");
+            ranksYml.set("Ranks." + messageString + ".NameTag.HideOnSneak", true);
+            ranksYml.set("Ranks." + messageString + ".Permission", "slimeranks.rank." + messageString);
+            Main.getRanksYml().saveYmlConfig();
+            RankManager.getInstance().reloadRanks();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(new Rank(messageString)).getInventory());
+        } else if (chatInputType == ChatInputType.RANK_TAB_FORMAT) {
+            Rank rank = (Rank) linkedObject;
+            rank.setTabFormat(messageString);
+            RankManager.getInstance().reloadDisplays();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(rank).getInventory());
+        } else if (chatInputType == ChatInputType.RANK_CHAT_FORMAT) {
+            Rank rank = (Rank) linkedObject;
+            rank.setChatFormat(messageString);
+            RankManager.getInstance().reloadDisplays();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(rank).getInventory());
+        } else if (chatInputType == ChatInputType.RANK_NAME_TAG_FORMAT) {
+            Rank rank = (Rank) linkedObject;
+            rank.setNameTagFormat(messageString);
+            RankManager.getInstance().reloadDisplays();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(rank).getInventory());
+        } else if (chatInputType == ChatInputType.RANK_TAB_PRIORITY) {
+            if (!messageString.chars().allMatch(Character::isDigit)) {
+                Component additionalInfoMessage = new Message("Chat.Input.OnlyNumbers", true).getMessage();
+                endSession(true, additionalInfoMessage, false);
+                return;
+            }
+
+            int priority = Integer.parseInt(messageString);
+
+            if (priority < 0) {
+                Component additionalInfoMessage = new Message("Chat.Input.HigherThanZero", true).getMessage();
+                endSession(true, additionalInfoMessage, false);
+                return;
+            }
+
+            Rank rank = (Rank) linkedObject;
+            rank.setPriority(priority);
+            RankManager.getInstance().reloadDisplays();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(rank).getInventory());
+        } else if (chatInputType == ChatInputType.RANK_PERMISSION) {
+            Rank rank = (Rank) linkedObject;
+            rank.setPermission(messageString);
+            RankManager.getInstance().reloadDisplays();
+            endSession(true, null, true);
+            player.openInventory(new RankEditGui(rank).getInventory());
+        } else {
+            endSession(true, null, false);
+        }
+    }
+
+    public static boolean playerHasActivateChatInputSession(Player player) {
+        return chatInputSessions.containsKey(player);
+    }
+
+    public static ChatInput getChatInputSession(Player player) {
+        return chatInputSessions.get(player);
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/objects/ItemBuilder.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/ItemBuilder.java
@@ -1,0 +1,83 @@
+package de.lxca.slimeRanks.objects;
+
+import de.lxca.slimeRanks.Main;
+import net.kyori.adventure.text.Component;
+import org.bukkit.*;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class ItemBuilder {
+
+    private final ItemStack itemStack;
+    private final ItemMeta itemMeta;
+
+    public ItemBuilder(Material material) {
+        itemStack = new ItemStack(material);
+        itemMeta = itemStack.getItemMeta();
+    }
+
+    public ItemBuilder(Material material, int amount) {
+        itemStack = new ItemStack(material, amount);
+        itemMeta = itemStack.getItemMeta();
+    }
+
+    public void setItemName(String messageKey) {
+        setItemName(messageKey, null);
+    }
+
+    public void setItemName(String messageKey, HashMap<String, String> replacements) {
+        if (replacements == null) {
+            itemMeta.itemName(new Message(messageKey).getMessage());
+        } else {
+            itemMeta.itemName(new Message(messageKey, replacements).getMessage());
+        }
+    }
+
+    public void setLore(String messageKey) {
+        setLore(messageKey, null);
+    }
+
+    public void setLore(String messageKey, HashMap<String, String> replacements) {
+        ArrayList<Component> lore;
+
+        if (replacements == null) {
+            lore = new Message(messageKey).getLore();
+        } else {
+            lore = new Message(messageKey, replacements).getLore();
+        }
+
+        if (lore == null) {
+            return;
+        }
+
+        itemMeta.lore(lore);
+    }
+
+    public void addItemFlag(ItemFlag itemFlag) {
+        itemMeta.addItemFlags(itemFlag);
+        itemMeta.addAttributeModifier(
+                Attribute.ARMOR,
+                new AttributeModifier(
+                        new NamespacedKey(Main.getInstance(), UUID.randomUUID().toString()),
+                        0,
+                        AttributeModifier.Operation.ADD_NUMBER
+                )
+        );
+    }
+
+    public void setHideTooltip(boolean value) {
+        itemMeta.setHideTooltip(value);
+    }
+
+    public ItemStack getItemStack() {
+        itemStack.setItemMeta(itemMeta);
+        return itemStack;
+    }
+}

--- a/src/main/java/de/lxca/slimeRanks/objects/Message.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Message.java
@@ -55,7 +55,7 @@ public class Message {
 
         if (messageString == null) {
             Main.getLogger(this.getClass()).warn("Message with key {} not found in messages.yml!", messageKey);
-            return null;
+            return MiniMessage.miniMessage().deserialize(messageKey);
         }
 
         if (withPrefix) {

--- a/src/main/java/de/lxca/slimeRanks/objects/Message.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Message.java
@@ -51,24 +51,29 @@ public class Message {
         this.replacements = replacements;
     }
 
-    public Component getMessage() {
+    public String getRawMessage() {
         String messageString = Main.getMessagesYml().getYmlConfig().getString(messageKey, null);
 
         if (messageString == null) {
             Main.getLogger(this.getClass()).warn("Message with key {} not found in messages.yml!", messageKey);
-            return MiniMessage.miniMessage().deserialize(messageKey);
+            return messageKey;
         }
 
         if (withPrefix) {
             messageString = getPrefix() + messageString;
         }
 
+        HashMap<String, String> replacements = getReplacedReplacements();
         for (String key : replacements.keySet()) {
             String regex = "\\{" + key + "}";
             messageString = messageString.replaceAll(regex, replacements.get(key));
         }
 
-        return MiniMessage.miniMessage().deserialize(messageString);
+        return messageString;
+    }
+
+    public Component getMessage() {
+        return MiniMessage.miniMessage().deserialize(getRawMessage());
     }
 
     public ArrayList<Component> getLore() {
@@ -79,6 +84,7 @@ public class Message {
             return null;
         }
 
+        HashMap<String, String> replacements = getReplacedReplacements();
         ArrayList<Component> loreLineComponents = new ArrayList<>();
 
         for (Object loreLine : loreLines) {

--- a/src/main/java/de/lxca/slimeRanks/objects/Message.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Message.java
@@ -44,6 +44,13 @@ public class Message {
         this.replacements = new HashMap<>();
     }
 
+    public Message(@NotNull String messageKey, boolean withPrefix) {
+        this.commandSender = null;
+        this.withPrefix = withPrefix;
+        this.messageKey = messageKey;
+        this.replacements = new HashMap<>();
+    }
+
     public Message(@NotNull String messageKey, @NotNull HashMap<String, String> replacements) {
         this.commandSender = null;
         this.withPrefix = false;
@@ -89,7 +96,7 @@ public class Message {
 
         for (Object loreLine : loreLines) {
             if (!(loreLine instanceof String loreLineString)) {
-                Main.getLogger(this.getClass()).warn("Message with key {} contains non-string lore line at index {} in messages.yml!", messageKey, loreLines.indexOf(loreLine));
+                Main.getLogger(this.getClass()).warn("Message with key {} contains non-string lore line at index {} in messages.yml!", messageKey, String.valueOf(loreLines.indexOf(loreLine)));
                 continue;
             }
 

--- a/src/main/java/de/lxca/slimeRanks/objects/Message.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Message.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Message {
 
@@ -95,6 +96,24 @@ public class Message {
         }
 
         return loreLineComponents;
+    }
+
+    private @NotNull HashMap<String, String> getReplacedReplacements() {
+        HashMap<String, String> replacements = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : this.replacements.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            if (value != null && value.startsWith("%")) {
+                String valueMessage = new Message(value.substring(1)).getRawMessage();
+                replacements.put(key, valueMessage);
+            } else {
+                replacements.put(key, value);
+            }
+        }
+
+        return replacements;
     }
 
     public void sendMessage() {

--- a/src/main/java/de/lxca/slimeRanks/objects/Rank.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Rank.java
@@ -153,4 +153,10 @@ public class Rank {
         Main.getRanksYml().saveYmlConfig();
         this.permission = permission;
     }
+
+    public void delete() {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier, null);
+        Main.getRanksYml().saveYmlConfig();
+        RankManager.getInstance().reloadRanks();
+    }
 }

--- a/src/main/java/de/lxca/slimeRanks/objects/Rank.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Rank.java
@@ -58,6 +58,10 @@ public class Rank {
         return MiniMessage.miniMessage().deserialize(tabFormat.replace("{player}", player.getName()));
     }
 
+    public String getRawTabFormat() {
+        return tabFormat;
+    }
+
     public void setTabFormat(@NotNull String tabFormat) {
         Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Tab.Format", tabFormat);
         Main.getRanksYml().saveYmlConfig();
@@ -92,6 +96,10 @@ public class Rank {
         return MiniMessage.miniMessage().deserialize(chatFormat.replace("{player}", player.getName()).replace("{message}", message));
     }
 
+    public String getRawChatFormat() {
+        return chatFormat;
+    }
+
     public void setChatFormat(@NotNull String chatFormat) {
         Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Chat.Format", chatFormat);
         Main.getRanksYml().saveYmlConfig();
@@ -114,6 +122,10 @@ public class Rank {
         }
 
         return MiniMessage.miniMessage().deserialize(nameTagFormat.replace("{player}", player.getName()));
+    }
+
+    public String getRawNameTagFormat() {
+        return nameTagFormat;
     }
 
     public void setNameTagFormat(@NotNull String nameTagFormat) {

--- a/src/main/java/de/lxca/slimeRanks/objects/Rank.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Rank.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class Rank {
 
@@ -135,7 +136,7 @@ public class Rank {
         return permission;
     }
 
-    public void setPermission(@NotNull String permission) {
+    public void setPermission(@Nullable String permission) {
         Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Permission", permission);
         Main.getRanksYml().saveYmlConfig();
         this.permission = permission;

--- a/src/main/java/de/lxca/slimeRanks/objects/Rank.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/Rank.java
@@ -10,15 +10,15 @@ import org.jetbrains.annotations.NotNull;
 public class Rank {
 
     private final String identifier;
-    private final boolean tabActive;
-    private final String tabFormat;
-    private final int priority;
-    private final boolean chatActive;
-    private final String chatFormat;
-    private final boolean nameTagActive;
-    private final String nameTagFormat;
-    private final boolean hideNameTagOnSneak;
-    private final String permission;
+    private boolean tabActive;
+    private String tabFormat;
+    private int priority;
+    private boolean chatActive;
+    private String chatFormat;
+    private boolean nameTagActive;
+    private String nameTagFormat;
+    private boolean hideNameTagOnSneak;
+    private String permission;
 
     public Rank(String identifier) {
         YamlConfiguration ranksYml = Main.getRanksYml().getYmlConfig();
@@ -43,6 +43,12 @@ public class Rank {
         return tabActive;
     }
 
+    public void setTabActive(boolean tabActive) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Tab.Active", tabActive);
+        Main.getRanksYml().saveYmlConfig();
+        this.tabActive = tabActive;
+    }
+
     public Component getTabFormat(@NotNull Player player) {
         if (tabFormat == null) {
             return null;
@@ -51,12 +57,30 @@ public class Rank {
         return MiniMessage.miniMessage().deserialize(tabFormat.replace("{player}", player.getName()));
     }
 
+    public void setTabFormat(@NotNull String tabFormat) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Tab.Format", tabFormat);
+        Main.getRanksYml().saveYmlConfig();
+        this.tabFormat = tabFormat;
+    }
+
     public int getPriority() {
         return priority;
     }
 
+    public void setPriority(int priority) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Tab.Priority", priority);
+        Main.getRanksYml().saveYmlConfig();
+        this.priority = priority;
+    }
+
     public boolean chatIsActive() {
         return chatActive;
+    }
+
+    public void setChatActive(boolean chatActive) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Chat.Active", chatActive);
+        Main.getRanksYml().saveYmlConfig();
+        this.chatActive = chatActive;
     }
 
     public Component getChatFormat(@NotNull Player player, @NotNull String message) {
@@ -67,8 +91,20 @@ public class Rank {
         return MiniMessage.miniMessage().deserialize(chatFormat.replace("{player}", player.getName()).replace("{message}", message));
     }
 
+    public void setChatFormat(@NotNull String chatFormat) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Chat.Format", chatFormat);
+        Main.getRanksYml().saveYmlConfig();
+        this.chatFormat = chatFormat;
+    }
+
     public boolean nameTagIsActive() {
         return nameTagActive;
+    }
+
+    public void setNameTagActive(boolean nameTagActive) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".NameTag.Active", nameTagActive);
+        Main.getRanksYml().saveYmlConfig();
+        this.nameTagActive = nameTagActive;
     }
 
     public Component getNameTagFormat(@NotNull Player player) {
@@ -79,11 +115,29 @@ public class Rank {
         return MiniMessage.miniMessage().deserialize(nameTagFormat.replace("{player}", player.getName()));
     }
 
+    public void setNameTagFormat(@NotNull String nameTagFormat) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".NameTag.Format", nameTagFormat);
+        Main.getRanksYml().saveYmlConfig();
+        this.nameTagFormat = nameTagFormat;
+    }
+
     public boolean hideNameTagOnSneak() {
         return hideNameTagOnSneak;
     }
 
+    public void setHideNameTagOnSneak(boolean hideNameTagOnSneak) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".NameTag.HideOnSneak", hideNameTagOnSneak);
+        Main.getRanksYml().saveYmlConfig();
+        this.hideNameTagOnSneak = hideNameTagOnSneak;
+    }
+
     public String getPermission() {
         return permission;
+    }
+
+    public void setPermission(@NotNull String permission) {
+        Main.getRanksYml().getYmlConfig().set("Ranks." + identifier + ".Permission", permission);
+        Main.getRanksYml().saveYmlConfig();
+        this.permission = permission;
     }
 }

--- a/src/main/java/de/lxca/slimeRanks/objects/RankManager.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/RankManager.java
@@ -41,6 +41,10 @@ public class RankManager {
         return instance;
     }
 
+    public ArrayList<Rank> getRanks() {
+        return new ArrayList<>(ranks);
+    }
+
     public int getRankCount() {
         return ranks.size();
     }

--- a/src/main/java/de/lxca/slimeRanks/objects/RankManager.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/RankManager.java
@@ -21,6 +21,19 @@ public class RankManager {
     private static final NamespacedKey rankKey = new NamespacedKey(Main.getInstance(), "slimeranks_rank");
 
     private RankManager() {
+        reloadRanks();
+    }
+
+    public static synchronized RankManager getInstance() {
+        if (instance == null) {
+            instance = new RankManager();
+        }
+
+        return instance;
+    }
+
+    public void reloadRanks() {
+        ranks.clear();
         YamlConfiguration ranksYml = Main.getRanksYml().getYmlConfig();
         ConfigurationSection ranksSection = ranksYml.getConfigurationSection("Ranks");
 
@@ -31,14 +44,6 @@ public class RankManager {
         for (String identifier : ranksSection.getKeys(false)) {
             ranks.add(new Rank(identifier));
         }
-    }
-
-    public static synchronized RankManager getInstance() {
-        if (instance == null) {
-            instance = new RankManager();
-        }
-
-        return instance;
     }
 
     public ArrayList<Rank> getRanks() {
@@ -137,7 +142,7 @@ public class RankManager {
         }
     }
 
-    public void reload() {
+    public void reloadDisplays() {
         for (World world : Bukkit.getWorlds()) {
             clearPlayerNameTags(world);
         }

--- a/src/main/java/de/lxca/slimeRanks/objects/configurations/MessagesYml.java
+++ b/src/main/java/de/lxca/slimeRanks/objects/configurations/MessagesYml.java
@@ -1,5 +1,7 @@
 package de.lxca.slimeRanks.objects.configurations;
 
+import java.util.List;
+
 public class MessagesYml extends Yml {
 
     private static final String filePath = "plugins/SlimeRanks/";
@@ -13,10 +15,72 @@ public class MessagesYml extends Yml {
     @Override
     protected void setDefaultYmlKeys() {
         createConfigKey("Chat.Brand", "<color:#39ff14><b>SlimeRanks</b></color> <dark_gray>»</dark_gray> ");
+
         createConfigKey("Chat.Command.Reload", "<gray>The configurations have been reloaded</gray><dark_gray>.</dark_gray>");
         createConfigKey("Chat.Command.About", "<newline><dark_gray>-==========- <color:#39ff14><b>Slimeranks</b></color> -==========-</dark_gray><newline><newline><dark_gray>|</dark_gray> <gray>Description</gray><dark_gray>:</dark_gray> <color:#39ff14>{description}</color><newline><dark_gray>|</dark_gray> <gray>Author</gray><dark_gray>:</dark_gray> <color:#39ff14>{author}</color><newline><dark_gray>|</dark_gray> <gray>Version</gray><dark_gray>:</dark_gray> <color:#39ff14>{version}</color><newline><newline><dark_gray>-==========- <color:#39ff14><b>Slimeranks</b></color> -==========-</dark_gray><newline>");
         createConfigKey("Chat.Command.Help", "<newline><dark_gray>-==========- <color:#39ff14><b>Slimeranks</b></color> -==========-</dark_gray><newline><newline><dark_gray>|</dark_gray> <color:#39ff14>/slimeranks about</color> <dark_gray>|</dark_gray> <gray>Displays information about SlimeRanks</gray><dark_gray>.</dark_gray><newline><dark_gray>|</dark_gray> <color:#39ff14>/slimeranks help</color> <dark_gray>|</dark_gray> <gray>Shows this help message</gray><dark_gray>.</dark_gray><newline><dark_gray>|</dark_gray> <color:#39ff14>/slimeranks reload</color> <dark_gray>|</dark_gray> <gray>Reloads the configurations</gray><dark_gray>.</dark_gray><newline><newline><dark_gray>-==========- <color:#39ff14><b>Slimeranks</b></color> -==========-</dark_gray><newline>");
         createConfigKey("Chat.Command.Unknown", "<gray>The command <color:#39ff14>{command}</color> is unknown<dark_gray>.</dark_gray> Use <color:#39ff14>/slimeranks help</color> to see all available commands</gray><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Command.OnlyPlayers", "<red>Only players can use this command</red><dark_gray>.</dark_gray>");
+
+        createConfigKey("Chat.Input.Started", "<gray>Chat input started<dark_gray>.</dark_gray> To cancel the process<dark_gray>,</dark_gray> write</gray> <color:#39ff24>cancel</color><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.Ended", "<gray>Chat input session ended</gray><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.RankIdentifier.OnlyLetters", "<red>The rank identifier can only contain letters</red><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.RankIdentifier.AlreadyUsed", "<red>The rank identifier is already in use</red><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.OnlyNumbers", "<red>The input must only contain numbers</red><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.HigherThanZero", "<red>The input must be greater than or equal to</red> <color:#ff1439>0</color><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.CreateRank", "<gray>Please enter the desired identifier for the rank</gray><dark_gray>.</dark_gray><newline><gray>Only letters are allowed</gray><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.TabFormat", "<gray>Please enter the desired <color:#39ff14>Tablist Format</color> in <color:#39ff14>MiniMessage format</color></gray><dark_gray>.</dark_gray><newline><gray>The following placeholders are supported</gray><dark_gray>:</dark_gray> <color:#39ff14>{player}</color><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.ChatFormat", "<gray>Please enter the desired <color:#39ff14>Chat Format</color> in <color:#39ff14>MiniMessage format</color></gray><dark_gray>.</dark_gray><newline><gray>The following placeholders are supported</gray><dark_gray>:</dark_gray> <color:#39ff14>{player}<dark_gray>,</dark_gray> {message}</color><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.NameTagFormat", "<gray>Please enter the desired <color:#39ff14>NameTag Format</color> in <color:#39ff14>MiniMessage format</color></gray><dark_gray>.</dark_gray><newline><gray>The following placeholders are supported</gray><dark_gray>:</dark_gray> <color:#39ff14>{player}</color><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.TabPriority", "<gray>Please enter the desired <color:#39ff14>tab priority</color> as a <color:#39ff14>number</color><dark_gray>.</dark_gray></gray><newline><gray>The higher the number<dark_gray>,</dark_gray> the higher the rank will be displayed<dark_gray>.</dark_gray> A value of <color:#39ff14>0</color> disables sorting</gray><dark_gray>.</dark_gray>");
+        createConfigKey("Chat.Input.Permission", "<gray>Please enter the required <color:#39ff14>permission</color> the player needs to obtain the rank</gray><dark_gray>.</dark_gray>");
+
+        createConfigKey("Gui.Global.ItemName.Close", "<color:#ff1439><u>Close</u></color>");
+        createConfigKey("Gui.Global.ItemName.Back", "<color:#39ff14><u>Back</u></color>");
+        createConfigKey("Gui.Global.ItemName.PreviousPage", "<color:#39ff14><u>Previous page</u></color>");
+        createConfigKey("Gui.Global.ItemName.NextPage", "<color:#39ff14><u>Next page</u></color>");
+        createConfigKey("Gui.Global.ItemName.Rank", "<color:#39ff14>{identifier}</color>");
+        createConfigKey("Gui.Global.ItemLore.Rank", List.of("", "<gray>Identifier</gray><dark_gray>:</dark_gray> <color:#39ff14>{identifier}</color>", "<gray>Tablist format</gray><dark_gray>:</dark_gray> <white>{tablist_format}</white>", "<gray>Chat format</gray><dark_gray>:</dark_gray> <white>{chat_format}</white>", "<gray>Name tag format</gray><dark_gray>:</dark_gray> <white>{name_tag_format}</white>", "", "<gray>Tab priority</gray><dark_gray>:</dark_gray> <color:#39ff14>{tab_priority}</color>", "<gray>Permission</gray><dark_gray>:</dark_gray> <color:#39ff14>{permission}</color>", "<gray>Hide name tag on sneak</gray><dark_gray>:</dark_gray> <color:#39ff14>{hide_name_tag_on_sneak}</color>"));
+
+        createConfigKey("Gui.Overview.Title", "Rank overview");
+        createConfigKey("Gui.Overview.ItemName.Title", "<color:#39ff14><b>Rank overview</b></color>");
+        createConfigKey("Gui.Overview.ItemName.Reload", "<color:#39ff14><u>Reload configurations</u></color>");
+        createConfigKey("Gui.Overview.ItemName.CreateRank", "<color:#39ff14><u>Create rank</u></color>");
+        createConfigKey("Gui.Overview.ItemLore.Title", List.of("", "<gray>In this overview you can manage</gray>", "<gray>and customize all your ranks</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Overview.ItemLore.Reload", List.of("", "<color:#39ff14>Click</color> <gray>to reload all plugin configurations</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Overview.ItemLore.CreateRank", List.of("", "<color:#39ff14>Click</color> <gray>to create a new rank</gray><dark_gray>.</dark_gray>"));
+
+        createConfigKey("Gui.Edit.Title", "Edit rank ({identifier})");
+        createConfigKey("Gui.Edit.ItemName.Tablist", "<color:#39ff14><u>Tablist format</u></color>");
+        createConfigKey("Gui.Edit.ItemName.Chat", "<color:#39ff14><u>Chat format</u></color>");
+        createConfigKey("Gui.Edit.ItemName.NameTag", "<color:#39ff14><u>Name tag format</u></color>");
+        createConfigKey("Gui.Edit.ItemName.TabPriority", "<color:#39ff14><u>Tab priority</u></color>");
+        createConfigKey("Gui.Edit.ItemName.Permission", "<color:#39ff14><u>Permission</u></color>");
+        createConfigKey("Gui.Edit.ItemName.HideOnSneak", "<color:#39ff14><u>Hide name tag on sneak</u></color>");
+        createConfigKey("Gui.Edit.ItemName.Delete", "<color:#ff1439><u>Delete rank</u></color>");
+        createConfigKey("Gui.Edit.ItemName.Status.Activated", "<color:#39ff14><u>Activated</u></color>");
+        createConfigKey("Gui.Edit.ItemName.Status.Deactivated", "<color:#ff1439><u>Deactivated</u></color>");
+        createConfigKey("Gui.Edit.ItemName.PriorityStatus", "<gray>Current priority</gray><dark_gray>:</dark_gray> <color:#39ff14>{priority}</color>");
+        createConfigKey("Gui.Edit.ItemName.PermissionStatus", "<gray>Current permission</gray><dark_gray>:</dark_gray> <color:#39ff14>{permission}</color>");
+        createConfigKey("Gui.Edit.ItemLore.Tablist", List.of("", "<gray>The Tablist format defines how the rank</gray>", "<gray>should be displayed in the tablist</gray><dark_gray>.</dark_gray>", "", "<gray>Current format</gray><dark_gray>:</dark_gray> <white>{format}</white>", "", "<color:#39ff14>Click</color> <gray>to customize the format</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.Chat", List.of("", "<gray>The chat format determines how</gray>", "<gray>the rank is displayed in the chat</gray><dark_gray>.</dark_gray>", "", "<gray>Current format</gray><dark_gray>:</dark_gray> <white>{format}</white>", "", "<color:#39ff14>Click</color> <gray>to customize the format</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.NameTag", List.of("", "<gray>The name tag format determines how the</gray>", "<gray>rank should be displayed above the player</gray><dark_gray>.</dark_gray>", "", "<gray>Current format</gray><dark_gray>:</dark_gray> <white>{format}</white>", "", "<color:#39ff14>Click</color> <gray>to customize the format</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.TabPriority", List.of("", "<gray>The tab priority determines how the</gray>", "<gray>rank should be sorted in the tab list</gray><dark_gray>.</dark_gray>", "<gray>The higher the number<dark_gray>,</dark_gray> the higher up</gray>", "<gray>the rank is displayed</gray><dark_gray>.</dark_gray>", "<gray>If the value is <color:#39ff14>0</color><dark_gray>,</dark_gray> no sorting is performed</gray><dark_gray>.</dark_gray>", "", "<gray>Current priority</gray><dark_gray>:</dark_gray> <color:#39ff14>{priority}</color>"));
+        createConfigKey("Gui.Edit.ItemLore.Permission", List.of("", "<gray>The permission determines which</gray>", "<gray>permission a player must have</gray>", "<gray>in order to obtain the rank</gray><dark_gray>.</dark_gray>", "", "<gray>Current permission</gray><dark_gray>:</dark_gray> <color:#39ff14>{permission}</color>"));
+        createConfigKey("Gui.Edit.ItemLore.HideOnSneak", List.of("", "<gray>Hiding the name tag when sneaking</gray>", "<gray>determines whether the player<dark_gray>'</dark_gray>s name tag</gray>", "<gray>should be hidden when the player sneaks</gray><dark_gray>.</dark_gray>", "", "<gray>Current status</gray><dark_gray>:</dark_gray> <color:#39ff14>{status}</color>"));
+        createConfigKey("Gui.Edit.ItemLore.Delete", List.of("", "<gray>You can use this button to delete the rank</gray><dark_gray>.</dark_gray>", "<gray>Use this button with caution as there</gray>", "<gray>is no second confirmation</gray><dark_gray>.</dark_gray>", "", "<color:#ff1439>Double-click</color> <gray>to delete the rank</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.Status.Activated", List.of("", "<color:#39ff14>Click</color> <gray>to deactivate this feature</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.Status.Deactivated", List.of("", "<color:#39ff14>Click</color> <gray>to activate this feature</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.PriorityStatus", List.of("", "<color:#39ff14>Click</color> <gray>to to set the tab priority</gray><dark_gray>.</dark_gray>"));
+        createConfigKey("Gui.Edit.ItemLore.PermissionStatus", List.of("", "<color:#39ff14>Click</color> <gray>to set the permission</gray><dark_gray>.</dark_gray>", "<color:#39ff14>Double Click</color> <gray>to remove the permission</gray><dark_gray>.</dark_gray>"));
+
+        createConfigKey("Title.ChatInput.Main", "<color:#39ff14><b>Chat input</b></color>");
+        createConfigKey("Title.ChatInput.Sub", "<color:#39ff14>{seconds}</color> <gray>seconds left</gray><dark_gray>.</dark_gray>");
+
+        createConfigKey("Placeholder.None", "None");
+        createConfigKey("Placeholder.Yes", "Yes");
+        createConfigKey("Placeholder.No", "No");
+
         saveYmlConfig();
     }
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `slimeRanks` plugin. The changes include adding new GUI components for rank management, enhancing command functionality, and refactoring existing code for better maintainability.

### New Features:
* **Rank Management GUIs:**
  - Added `RankEditGui` for editing rank properties.
  - Added `RankOverviewGui` for viewing and managing ranks.
  - Created `EditItems` and `GlobalItems` to manage GUI item components. [[1]](diffhunk://#diff-41754276de8cfe5dec687a83f5c1ba2ca72bbcf5f70b41fd023f6f35568bc5f7R1-R134) [[2]](diffhunk://#diff-c9ab03d0c7c7ae43d0685996e759549dfbafceb48b4bed88b6d5560c3a8a2488R1-R76)

### Command Enhancements:
* **Command Additions:**
  - Added a new "gui" command to open the rank overview GUI.
  - Updated command auto-completion to include the new "gui" option.

### Code Refactoring:
* **Refactored `Main` Class:**
  - Replaced `RankManager.getInstance().reload()` with `RankManager.getInstance().reloadDisplays()` in `onEnable` method.
  - Added a `reload` method to centralize the reloading logic.

### Enum Additions:
* **New Enum for Chat Input Types:**
  - Added `ChatInputType` enum to categorize different chat input types for rank properties.

### Listener Additions:
* **Event Listener:**
  - Registered a new `InventoryClickListener` to handle inventory click events.